### PR TITLE
Use a CP check for whether a dependency is a dev pod

### DIFF
--- a/lib/pod/command/check.rb
+++ b/lib/pod/command/check.rb
@@ -41,7 +41,7 @@ module Pod
       def find_development_pods(podfile)
         development_pods = {}
         podfile.dependencies.each do |dependency|
-          development_pods[dependency.name] = dependency.external_source if dependency.external?
+          development_pods[dependency.name] = dependency.external_source if dependency.local?
         end
         development_pods
       end


### PR DESCRIPTION
To quote [the Core](https://github.com/CocoaPods/Core/blob/master/lib/cocoapods-core/dependency.rb#L150-L156):

```
    # @return [Bool] whether the dependency points to an external source.
    #
    def external?
      !@external_source.nil?
    end

    # @return [Bool] whether the dependency points to a local path.
    #
    def local?
      if external_source
        external_source[:path]
      end
    end
```

I think the usage of `external?` is returning a wider net than you wanted, at least I couldn't use CocoaPods Check on [artsy/eigen](https://github.com/artsy/eigen) 

Specs still pass:

```
~/d/r/l/cocoapods-check (master) ⏛  rake spec
/Users/orta/.rvm/rubies/ruby-2.1.3/bin/ruby -I/Users/orta/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.4.4/lib:/Users/orta/.rvm/gems/ruby-2.1.3/gems/rspec-support-3.4.1/lib /Users/orta/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.4.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.....

Finished in 2.04 seconds (files took 0.14975 seconds to load)
5 examples, 0 failures
```
