### PR TITLE
Include the absolute path of the local podspec instead of relative

### DIFF
--- a/lib/cocoapods_check.rb
+++ b/lib/cocoapods_check.rb
@@ -1,3 +1,3 @@
 module CocoapodsCheck
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/lib/pod/command/check.rb
+++ b/lib/pod/command/check.rb
@@ -41,7 +41,10 @@ module Pod
       def find_development_pods(podfile)
         development_pods = {}
         podfile.dependencies.each do |dependency|
-          development_pods[dependency.name] = dependency.external_source if dependency.local?
+          if dependency.local?
+            development_pods[dependency.name] = dependency.external_source.clone
+            development_pods[dependency.name][:path] = File.absolute_path(development_pods[dependency.name][:path])
+          end
         end
         development_pods
       end


### PR DESCRIPTION
/cc @justinseanmartin @mdiiorio 

If podspecs use `require_relative` then `pod check` fails because it uses relative paths to load the local podspecs.

This converts it to use absolute paths so `require_relative` inside podspecs now works.