### PR TITLE
Check if Podfile and Podfile.lock match

### DIFF
--- a/lib/pod/command/check.rb
+++ b/lib/pod/command/check.rb
@@ -35,10 +35,19 @@ module Pod
           raise Informative, 'Missing Podfile.lock!'
         end
 
+        unless podfile_matches_lockfile?(config)
+          raise Informative, 'Podfile does not match Podfile.lock!'
+        end
+
         development_pods = find_development_pods(config.podfile)
         results = find_differences(config, development_pods)
         has_same_manifests = check_manifests(config)
         print_results(results, has_same_manifests)
+      end
+
+      def podfile_matches_lockfile?(config)
+        podfile_changes = config.lockfile.detect_changes_with_podfile(config.podfile)
+        podfile_changes[:added].empty? && podfile_changes[:changed].empty? && podfile_changes[:removed].empty?
       end
 
       def check_manifests(config)

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -149,12 +149,32 @@ describe Pod::Command::Check do
     end
   end
 
+  it 'detects no differences between Podfile and Podfile.lock' do
+    check = Pod::Command::Check.new(CLAide::ARGV.new([]))
+    config = create_config({ :pod_one => '1.0', :pod_two => '2.0' }, { :pod_one => '1.0', :pod_two => '2.0' })
+    allow(config.lockfile).to receive(:detect_changes_with_podfile).with(config.podfile)
+                                                                   .and_return({added: [], changed: [], removed: []})
+
+    expect(check.podfile_matches_lockfile?(config)).to be_truthy
+  end
+
+  it 'detects differences between Podfile and Podfile.lock' do
+    check = Pod::Command::Check.new(CLAide::ARGV.new([]))
+    config = create_config({ :pod_one => '1.0', :pod_two => '2.0' }, { :pod_one => '1.0', :pod_two => '2.0' })
+    allow(config.lockfile).to receive(:detect_changes_with_podfile).with(config.podfile)
+                                                                   .and_return({added: [:pod_one], changed: [], removed: []})
+
+    expect(check.podfile_matches_lockfile?(config)).to be_falsey
+  end
+
   def create_config(lockfile_hash, manifest_hash)
     config = Pod::Config.new
+    podfile = double('podfile')
     lockfile = double('lockfile')
     sandbox = double('sandbox')
     manifest = double('manifest')
 
+    allow(config).to receive(:podfile).and_return(podfile)
     allow(config).to receive(:lockfile).and_return(lockfile)
     allow(config).to receive(:sandbox).and_return(sandbox)
     allow(sandbox).to receive(:manifest).and_return(manifest)


### PR DESCRIPTION
Currently, if changes are made to a `Podfile` and `pod check` is run, it passes and says there is nothing to install. I think it would be better if `pod check` could also detect changes to the `Podfile`.

I have added a small check to verify if `Podfile` and `Podfile.lock` match. This makes it more similar to how `bundle check` works.

Do you have thoughts on this? Let me know if there are changes you think I should make.