### PR TITLE
Adds option to ignore development pods

### DIFF
--- a/lib/pod/command/check.rb
+++ b/lib/pod/command/check.rb
@@ -19,12 +19,14 @@ module Pod
 
       def self.options
         [
-          ['--verbose', 'Show change details.']
+          ['--verbose', 'Show change details.'],
+          ['--ignore-dev-pods', 'Ignores updates to development pods.']
         ].concat(super)
       end
 
       def initialize(argv)
         @check_command_verbose = argv.flag?('verbose')
+        @check_command_ignore_dev_pods = argv.flag?('ignore-dev-pods')
         super
       end
 
@@ -78,6 +80,7 @@ module Pod
           if manifest_version
             # If this is a development pod do a modified time check
             if development_pods[spec_name] != nil
+              next if @check_command_ignore_dev_pods
               newer_files = get_files_newer_than_lockfile_for_podspec(config, development_pods[spec_name])
               if newer_files.any?
                 changed_development_result(spec_name, newer_files)


### PR DESCRIPTION
Good morning! I'm a big fan of this library, it really speeds up our CI build times. However, I [ran into a case yesterday](https://github.com/artsy/emission/pull/1255) where how it handles development pods (comparing files' last-modified times) doesn't work for our project, which integrates React Native and Objective-C code. To support our use case, I've added an `--ignore-dev-pods` flag that ignores development pods altogether. Thanks!